### PR TITLE
removing the ordinal suffixes in string

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@
 
 ## Features
 
+- [x] [Removing ordinal suffixes](#removing-ordinal-suffixes---source)
 - [x] [Adding ordinal suffixes](#adding-ordinal-suffixes---source)
 - [ ] Converting Persian words to number
 - [ ] Converting Persian numbers to word
@@ -35,12 +36,24 @@
 
 now let's look at examples and how work with apis in package
 
-- #### Adding Ordinal Suffixes - [source](https://github.com/persian-tools/dart-persian-tools/blob/master/lib/src/core/add_ordinal_suffix/add_ordinal_suffix.dart)
+- #### Adding Ordinal Suffixes - [source](https://github.com/persian-tools/dart-persian-tools/blob/master/lib/src/core/remove_ordinal_suffix/remove_ordinal_suffix.dart)
 
 ```dart
 var number = 'سی سه'; // or سی | شصت | پنجاه دو
 addOrdinalSuffix(number); // سی سوم | سی اُم | شصتم | پنجاه دوم
+
+/// or use it as String extension method
 number.withOrdinalSuffix // ... like so
+```
+
+- #### Removing Ordinal Suffixes - [source](https://github.com/persian-tools/dart-persian-tools/blob/master/lib/src/core/add_ordinal_suffix/add_ordinal_suffix.dart)
+
+```dart
+var number = 'چهل و سوم'; // سی سوم | سی اُم | شصتم | پنجاه دوم
+removeOrdinalSuffix(number); // سی | شصت | پنجاه دو
+
+/// or use it as String extension method
+number.withoutOrdinalSuffix; // ... like so
 ```
 
 - #### Adding and removing separator to / from numbers - [source](https://github.com/persian-tools/dart-persian-tools/blob/master/lib/src/core/commas/methods.dart)

--- a/example/example_remove_ordinal_suffix.dart
+++ b/example/example_remove_ordinal_suffix.dart
@@ -1,0 +1,9 @@
+import 'package:persian_tools/persian_tools.dart';
+
+void main() {
+  var number = 'چهل و سوم'; // سی سوم | سی اُم | شصتم | پنجاه دوم
+  print(removeOrdinalSuffix(number)); // سی | شصت | پنجاه دو
+
+  /// or use it as String extension method
+  print(number.withoutOrdinalSuffix); // ... like so
+}

--- a/lib/persian_tools.dart
+++ b/lib/persian_tools.dart
@@ -4,6 +4,9 @@ library persian_tools;
 // exports [addOrdinalSuffix] method and [AddOrdinalSuffix] extension
 export 'src/core/add_ordinal_suffix/add_ordinal_suffix.dart';
 
+// exports [removeOrdinalSuffix] method and [RemoveOrdinalSuffix] extension
+export 'src/core/remove_ordinal_suffix/remove_ordinal_suffix.dart';
+
 // exports [Bill] class
 export 'src/core/bill/bill.dart';
 

--- a/lib/src/core/remove_ordinal_suffix/remove_ordinal_suffix.dart
+++ b/lib/src/core/remove_ordinal_suffix/remove_ordinal_suffix.dart
@@ -1,0 +1,19 @@
+/// removes Ordinal Suffixes to numbers
+/// for example :
+/// ```dart
+/// removeOrdinalSuffix("سه هزارم") // سث هزار
+/// removeOrdinalSuffix("سه هزارمین") // سه هزار
+/// ```
+String removeOrdinalSuffix(String number) {
+  return number;
+}
+
+/// with RemoveOrdinalSuffix extension method you can use [removeOrdinalSuffix] method
+/// as a getter on String object
+/// ```dart
+/// var number = 'سی سه';
+/// number.withoutOrdinalSuffix; // سی سوم
+/// ```
+extension RemoveOrdinalSuffix on String {
+  String get withoutOrdinalSuffix => removeOrdinalSuffix(this);
+}

--- a/lib/src/core/remove_ordinal_suffix/remove_ordinal_suffix.dart
+++ b/lib/src/core/remove_ordinal_suffix/remove_ordinal_suffix.dart
@@ -1,11 +1,22 @@
 /// removes Ordinal Suffixes to numbers
 /// for example :
 /// ```dart
-/// removeOrdinalSuffix("سه هزارم") // سث هزار
-/// removeOrdinalSuffix("سه هزارمین") // سه هزار
+/// removeOrdinalSuffix('سه هزارم') // سث هزار
+/// removeOrdinalSuffix('سه هزارمین') // سه هزار
 /// ```
-String removeOrdinalSuffix(String number) {
-  return number;
+String removeOrdinalSuffix(String word) {
+  if (word.isEmpty) return word;
+
+  word = word
+      .replaceAll(RegExp('مین\$', caseSensitive: false), '')
+      .replaceAll(RegExp('(ام| اُم)\$', caseSensitive: false), '');
+  if (word.endsWith('سوم')) {
+    word = word.substring(0, word.length-3) + 'سه';
+  } else if (word.endsWith('م')) {
+    word = word.substring(0, word.length-1);
+  }
+
+  return word;
 }
 
 /// with RemoveOrdinalSuffix extension method you can use [removeOrdinalSuffix] method

--- a/test/test_remove_ordinal_suffix.dart
+++ b/test/test_remove_ordinal_suffix.dart
@@ -1,0 +1,13 @@
+import 'package:persian_tools/persian_tools.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('test Sheba/methods.dart', () {
+    test('test isValid getter', () {
+      expect(removeOrdinalSuffix('چهل و سوم'), equals('چهل و سه'));
+      expect(removeOrdinalSuffix('چهل و پنجم'), equals('چهل و پنج'));
+      expect(removeOrdinalSuffix('سی اُم'), equals('سی'));
+      expect(removeOrdinalSuffix(''), '');
+    });
+  });
+}


### PR DESCRIPTION
This method works exactly the opposite of the `addOrdinalSuffix` method.
```dart
var number ='چهل و سوم';
removeOrdinalSuffix(number); // چهل و سه
/// or use it as String extension method
number.withoutOrdinalSuffix; // ... like so
```

